### PR TITLE
buffer file reading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::io::BufReader;
 
 mod serde_utils;
 
@@ -34,5 +35,6 @@ pub mod api;
 
 pub fn json(file_path: &str) -> Vec<System> {
     let file = File::open(file_path).unwrap();
-    serde_json::from_reader(file).unwrap()
+    let reader = BufReader::new(file);
+    serde_json::from_reader(reader).unwrap()
 }


### PR DESCRIPTION
Currently EDSM systemPopulated.json is ~1.1Gb.
This is expected to grow further with addition of 'System Colonization'.
serde_json::from_reader() is quite slow when reading large files without buffering.

Ref:
https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html